### PR TITLE
Added functions for computing transform distances

### DIFF
--- a/ipd/sym/sym_util.py
+++ b/ipd/sym/sym_util.py
@@ -26,7 +26,7 @@ def compute_xform_distances(true_xforms, pred_xforms):
     assert true_xforms.shape == pred_xforms.shape
     dists = []
     for i, X in enumerate(true_xforms):
-        dists.append(X, pred_xforms[i])
+        dists.append(comb_dist(X, pred_xforms[i]))
     return th.stack(dists)
 
 def get_sym_frames(symid, opt, cenvec):


### PR DESCRIPTION
### **User description**
Adding in a few functions for computing transform distances and going from xyz_stack to complete set of xforms


___

### **Description**
- Introduced new functions for computing transform distances and handling coordinate stacks.
- Added `get_frames_from_xyz_stack` to retrieve transforms from a coordinate stack.
- Implemented `compute_xform_distances` for calculating deviations between true and predicted transformations.
- Added `comb_dist` to compute a combined distance metric for transformations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sym_util.py</strong><dd><code>New functions for transform distance calculations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ipd/sym/sym_util.py
<li>Added <code>get_frames_from_xyz_stack</code> function to extract transforms from a <br>stack of coordinates.<br> <li> Introduced <code>compute_xform_distances</code> function for calculating pairwise <br>deviations between transforms.<br> <li> Implemented <code>comb_dist</code> function to compute combined distances between <br>two transformations.<br> <li> Removed the previous inline definition of <code>comb_dist</code> from <code>get_nneigh</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/baker-laboratory/ipd/pull/43/files#diff-2975d9cb6b0430583afb712d43972e6865e469e528b2d3597e3caf2a5806cd44">+34/-12</a>&nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

